### PR TITLE
🔒 security: Replace hardcoded email recipients with environment variable

### DIFF
--- a/DEPLOYMENT_FIXES_SUMMARY.md
+++ b/DEPLOYMENT_FIXES_SUMMARY.md
@@ -6,7 +6,7 @@
 
 **Problem:**
 - Contact form showed "Email sent successfully"
-- No emails received at mehedims2005@gmail.com or hello@mehedims.com
+- No emails received at the intended recipient addresses
 
 **Root Cause:**
 - Emails were only sent to `MAIL_FROM` address (sender)
@@ -18,13 +18,17 @@
 to: process.env.MAIL_FROM
 
 // After (CORRECT):
-const recipients = ['mehedims2005@gmail.com', 'hello@mehedims.com'];
+const contactRecipients = process.env.CONTACT_RECIPIENTS;
+const recipients = contactRecipients
+  ? contactRecipients.split(',').map(email => email.trim())
+  : [process.env.MAIL_FROM || ''];
 to: recipients.join(', ')
 ```
 
 **Result:**
-- ✅ Emails now sent to BOTH addresses
-- ✅ Hardcoded recipient addresses (no env var needed)
+- ✅ Emails now sent to all configured recipient addresses
+- ✅ Removed hardcoded personal emails for better security
+- ✅ Customizable recipients via environment variable
 - ✅ Better logging for debugging
 
 ---
@@ -78,15 +82,18 @@ to: recipients.join(', ')
 **Changes:**
 - Added email format validation
 - Added SMTP connection verification
-- Fixed recipient addresses to send to both emails
+- Replaced hardcoded recipients with `CONTACT_RECIPIENTS` environment variable
 - Added detailed error handling
 - Added timeout settings
 - Improved logging
 
 **Key Changes:**
 ```javascript
-// Recipients hardcoded (guaranteed correct)
-const recipients = ['mehedims2005@gmail.com', 'hello@mehedims.com'];
+// Use environment variable for recipients or fallback to MAIL_FROM
+const contactRecipients = process.env.CONTACT_RECIPIENTS;
+const recipients = contactRecipients
+  ? contactRecipients.split(',').map(email => email.trim())
+  : [process.env.MAIL_FROM || ''];
 
 // Verify SMTP before sending
 await transporter.verify();
@@ -157,9 +164,7 @@ Comprehensive troubleshooting guide:
    ↓
 4. API verifies SMTP connection
    ↓
-5. API sends email to BOTH:
-   - mehedims2005@gmail.com
-   - hello@mehedims.com
+5. API sends email to all configured recipients in `CONTACT_RECIPIENTS`
    ↓
 6. API returns success/error
    ↓
@@ -167,9 +172,9 @@ Comprehensive troubleshooting guide:
 ```
 
 ### Email Recipients:
-- **Primary:** mehedims2005@gmail.com
-- **Secondary:** hello@mehedims.com
-- **Both receive:** Every contact form submission
+- **Configurable:** via `CONTACT_RECIPIENTS` environment variable
+- **Fallback:** to `MAIL_FROM` if not specified
+- **Multiple:** supports comma-separated list
 
 ---
 
@@ -188,6 +193,7 @@ SMTP_PORT=587
 SMTP_USER=your-gmail@gmail.com
 SMTP_PASSWORD=*** (16 chars)
 MAIL_FROM=your-gmail@gmail.com
+CONTACT_RECIPIENTS=your@email.com
 ```
 
 ### 2. Test Email Send:
@@ -199,15 +205,13 @@ MAIL_FROM=your-gmail@gmail.com
    heroku logs --tail
    ```
 5. Look for: "Email sent successfully"
-6. Check BOTH inboxes:
-   - mehedims2005@gmail.com
-   - hello@mehedims.com
+6. Check all recipient inboxes configured in `CONTACT_RECIPIENTS`.
 
 ### 3. Verify No Errors:
 - ✅ No console errors
 - ✅ No SMTP errors in logs
 - ✅ Success message shown
-- ✅ Both emails received
+- ✅ All configured recipients receive the email
 
 ---
 
@@ -288,15 +292,14 @@ After deployment:
    SMTP connection verified successfully
    Email sent successfully: {
      messageId: '<unique-id>',
-     accepted: ['mehedims2005@gmail.com', 'hello@mehedims.com'],
+     accepted: ['your@email.com', 'another@email.com'],
      rejected: []
    }
    ```
 
 3. **Email inboxes:**
-   - ✅ mehedims2005@gmail.com receives email
-   - ✅ hello@mehedims.com receives email
-   - ✅ Both show sender's message
+   - ✅ All configured recipient addresses receive the email
+   - ✅ Emails show sender's message
    - ✅ Reply-to set to sender's email
 
 ---

--- a/EMAIL_QUICK_REFERENCE.md
+++ b/EMAIL_QUICK_REFERENCE.md
@@ -2,11 +2,6 @@
 
 ## ✅ What You Need to Know
 
-### Email Recipients (Hardcoded):
-- ✅ `mehedims2005@gmail.com` (Primary)
-- ✅ `hello@mehedims.com` (Secondary)
-- **Both receive every contact form submission**
-
 ### Required Environment Variables:
 ```env
 SMTP_HOST=smtp.gmail.com
@@ -14,6 +9,7 @@ SMTP_PORT=587
 SMTP_USER=your-gmail@gmail.com
 SMTP_PASSWORD=<16-char-app-password>
 MAIL_FROM=your-gmail@gmail.com
+CONTACT_RECIPIENTS=your@email.com,another@email.com
 ```
 
 ---
@@ -34,11 +30,12 @@ heroku config:set SMTP_PORT=587
 heroku config:set SMTP_USER=your@gmail.com
 heroku config:set SMTP_PASSWORD=your-app-password
 heroku config:set MAIL_FROM=your@gmail.com
+heroku config:set CONTACT_RECIPIENTS=your@email.com,another@email.com
 ```
 
 **Vercel:**
 - Dashboard → Settings → Environment Variables
-- Add all 5 variables above
+- Add all 6 variables above
 
 **Local (.env.local):**
 ```env
@@ -47,6 +44,7 @@ SMTP_PORT=587
 SMTP_USER=your@gmail.com
 SMTP_PASSWORD=your-app-password
 MAIL_FROM=your@gmail.com
+CONTACT_RECIPIENTS=your@email.com,another@email.com
 ```
 
 ### Step 3: Test
@@ -79,8 +77,8 @@ MAIL_FROM=your@gmail.com
 
 You'll know it's working when:
 - ✅ Contact form shows: "Email sent successfully"
-- ✅ Logs show: `accepted: ['mehedims2005@gmail.com', 'hello@mehedims.com']`
-- ✅ Both emails received
+- ✅ Logs show: `accepted: ['your@email.com', 'another@email.com']`
+- ✅ Emails received at all configured addresses
 - ✅ No errors in logs
 
 ---

--- a/EMAIL_TROUBLESHOOTING.md
+++ b/EMAIL_TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 ## Issue: Contact Form Not Sending Emails
 
-If your contact form says "Email sent successfully" but you're not receiving emails at `mehedims2005@gmail.com` or `hello@mehedims.com`, follow this guide.
+If your contact form says "Email sent successfully" but you're not receiving emails at your configured recipient addresses, follow this guide.
 
 ---
 
@@ -10,9 +10,9 @@ If your contact form says "Email sent successfully" but you're not receiving ema
 
 Before diving into troubleshooting:
 
-- [ ] SMTP credentials are correctly set in environment variables
+- [ ] SMTP credentials and recipient addresses are correctly set in environment variables
 - [ ] Using Gmail App Password (not regular password)
-- [ ] Both email addresses exist and can receive mail
+- [ ] Recipient email addresses exist and can receive mail
 - [ ] Check spam/junk folder
 - [ ] SMTP server allows connections from your hosting platform
 
@@ -34,6 +34,7 @@ SMTP_PORT=587
 SMTP_USER=your-email@gmail.com
 SMTP_PASSWORD=your-16-char-app-password
 MAIL_FROM=your-email@gmail.com
+CONTACT_RECIPIENTS=your-email@gmail.com,another@email.com
 ```
 
 #### For Vercel:
@@ -48,6 +49,7 @@ SMTP_PORT=587
 SMTP_USER=your-email@gmail.com
 SMTP_PASSWORD=your-app-password
 MAIL_FROM=your-email@gmail.com
+CONTACT_RECIPIENTS=your-email@gmail.com,another@email.com
 ```
 
 ---
@@ -133,7 +135,7 @@ async function testEmail() {
     
     const info = await transporter.sendMail({
       from: 'your-email@gmail.com',
-      to: 'mehedims2005@gmail.com, hello@mehedims.com',
+      to: 'your@email.com, another@email.com',
       subject: 'Test Email',
       text: 'This is a test email',
     });
@@ -195,8 +197,8 @@ Look for errors like:
 #### Error: "Recipient address rejected"
 **Solution:**
 - Verify email addresses are correct
-- Check for typos in `mehedims2005@gmail.com` and `hello@mehedims.com`
-- Make sure both email addresses can receive mail
+- Check for typos in `CONTACT_RECIPIENTS` environment variable
+- Make sure all recipient email addresses can receive mail
 
 #### Error: No error but email not received
 **Solution:**
@@ -276,14 +278,13 @@ heroku logs --tail
    ```
    Email sent successfully: {
      messageId: '...',
-     accepted: ['mehedims2005@gmail.com', 'hello@mehedims.com'],
+     accepted: ['your@email.com', 'another@email.com'],
      rejected: []
    }
    ```
 
-4. **Check Both Email Inboxes:**
-   - mehedims2005@gmail.com
-   - hello@mehedims.com
+4. **Check All Recipient Email Inboxes:**
+   - Check all addresses configured in `CONTACT_RECIPIENTS`
    - Also check spam folder
 
 ---
@@ -295,8 +296,7 @@ After fixing, verify:
 - [ ] Environment variables are correct
 - [ ] Using Gmail App Password
 - [ ] SMTP connection test passes
-- [ ] Test email received at mehedims2005@gmail.com
-- [ ] Test email received at hello@mehedims.com
+- [ ] Test email received at all configured recipient addresses
 - [ ] Logs show "Email sent successfully"
 - [ ] No errors in application logs
 
@@ -331,8 +331,7 @@ If still having issues:
 
 You'll know it's working when:
 - ✅ Logs show "Email sent successfully"
-- ✅ Both emails received at mehedims2005@gmail.com
-- ✅ Both emails received at hello@mehedims.com
+- ✅ Emails received at all configured recipient addresses
 - ✅ No errors in application logs
 - ✅ Contact form shows success message
 

--- a/HEROKU_DEPLOYMENT.md
+++ b/HEROKU_DEPLOYMENT.md
@@ -18,6 +18,7 @@ The easiest way to deploy this portfolio to Heroku is using the one-click deploy
    - `SMTP_USER`: Your email address
    - `SMTP_PASSWORD`: Your email password or app-specific password
    - `MAIL_FROM`: Email address to send from (same as SMTP_USER)
+   - `CONTACT_RECIPIENTS`: Comma-separated list of recipient email addresses
    - `NEXT_PUBLIC_BASE_URL`: (Optional) Will be auto-set to your Heroku URL
 4. **Click "Deploy app"**
 5. Wait for the build to complete
@@ -52,6 +53,7 @@ The easiest way to deploy this portfolio to Heroku is using the one-click deploy
    heroku config:set SMTP_USER=your-email@gmail.com
    heroku config:set SMTP_PASSWORD=your-password
    heroku config:set MAIL_FROM=your-email@gmail.com
+   heroku config:set CONTACT_RECIPIENTS=your-email@gmail.com
    heroku config:set NODE_ENV=production
    ```
 
@@ -96,6 +98,7 @@ Heroku also supports Docker deployments using Container Registry.
    heroku config:set SMTP_USER=your-email@gmail.com
    heroku config:set SMTP_PASSWORD=your-password
    heroku config:set MAIL_FROM=your-email@gmail.com
+   heroku config:set CONTACT_RECIPIENTS=your-email@gmail.com
    ```
 
 4. **Build and push the Docker image:**
@@ -127,6 +130,7 @@ Make sure to set these environment variables in your Heroku app:
 | `SMTP_USER` | SMTP username/email | `your-email@gmail.com` |
 | `SMTP_PASSWORD` | SMTP password | `your-app-password` |
 | `MAIL_FROM` | Send from email | `your-email@gmail.com` |
+| `CONTACT_RECIPIENTS` | Recipient email(s) (comma-separated) | `your-email@gmail.com,other@email.com` |
 | `NEXT_PUBLIC_BASE_URL` | Base URL | `https://your-app.herokuapp.com` |
 
 ### Setting up Gmail SMTP

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ SMTP_PORT=587
 SMTP_USER=your-email@gmail.com
 SMTP_PASSWORD=your-gmail-app-password
 MAIL_FROM=your-email@gmail.com
+CONTACT_RECIPIENTS=your-email@gmail.com,another-email@example.com
 
 # Site Configuration
 NEXT_PUBLIC_BASE_URL=https://yourdomain.com
@@ -105,7 +106,7 @@ NEXT_PUBLIC_BASE_URL=https://yourdomain.com
 - See **[SMTP_SETUP_GUIDE.md](./SMTP_SETUP_GUIDE.md)** for detailed Gmail setup instructions
 - See **[EMAIL_TROUBLESHOOTING.md](./EMAIL_TROUBLESHOOTING.md)** if emails aren't being received
 
-**Emails are sent to:** `mehedims2005@gmail.com` and `hello@mehedims.com`
+**Emails are sent to:** The addresses specified in the `CONTACT_RECIPIENTS` environment variable (comma-separated).
 
 For production, set these environment variables in your hosting platform.
 

--- a/SMTP_SETUP_GUIDE.md
+++ b/SMTP_SETUP_GUIDE.md
@@ -1,6 +1,6 @@
 # SMTP Setup Guide for Gmail
 
-This guide will help you set up Gmail SMTP for the contact form to send emails to `mehedims2005@gmail.com` and `hello@mehedims.com`.
+This guide will help you set up Gmail SMTP for the contact form to send emails to your configured recipient addresses.
 
 ---
 
@@ -26,9 +26,7 @@ This guide will help you set up Gmail SMTP for the contact form to send emails t
 
 ### Step 3: Set Environment Variables
 
-The emails will be sent to **both addresses**:
-- `mehedims2005@gmail.com`
-- `hello@mehedims.com`
+The emails will be sent to the addresses configured in `CONTACT_RECIPIENTS`.
 
 #### For Heroku:
 ```bash
@@ -37,6 +35,7 @@ heroku config:set SMTP_PORT=587
 heroku config:set SMTP_USER=your-gmail@gmail.com
 heroku config:set SMTP_PASSWORD=abcdefghijklmnop
 heroku config:set MAIL_FROM=your-gmail@gmail.com
+heroku config:set CONTACT_RECIPIENTS=your@email.com,another@email.com
 ```
 
 #### For Vercel:
@@ -49,6 +48,7 @@ heroku config:set MAIL_FROM=your-gmail@gmail.com
    SMTP_USER = your-gmail@gmail.com
    SMTP_PASSWORD = abcdefghijklmnop
    MAIL_FROM = your-gmail@gmail.com
+   CONTACT_RECIPIENTS = your@email.com,another@email.com
    ```
 4. Click "Save"
 5. Redeploy your project
@@ -60,29 +60,14 @@ SMTP_PORT=587
 SMTP_USER=your-gmail@gmail.com
 SMTP_PASSWORD=abcdefghijklmnop
 MAIL_FROM=your-gmail@gmail.com
+CONTACT_RECIPIENTS=your@email.com,another@email.com
 ```
 
 ---
 
 ## 📧 Which Gmail Account to Use?
 
-You have 2 options:
-
-### Option 1: Use mehedims2005@gmail.com
-```env
-SMTP_USER=mehedims2005@gmail.com
-SMTP_PASSWORD=<app-password-for-mehedims2005>
-MAIL_FROM=mehedims2005@gmail.com
-```
-
-### Option 2: Use hello@mehedims.com (if it's Gmail)
-```env
-SMTP_USER=hello@mehedims.com
-SMTP_PASSWORD=<app-password-for-hello>
-MAIL_FROM=hello@mehedims.com
-```
-
-**Emails will be sent TO both addresses regardless of which one you use as sender.**
+You can use any Gmail account with 2FA enabled and an App Password. The `CONTACT_RECIPIENTS` variable determines where the messages are delivered, independent of the sender account.
 
 ---
 
@@ -112,9 +97,7 @@ heroku config --app your-app-name
    Message: This is a test message
    ```
 3. Click "Send Message"
-4. Check **both** email inboxes:
-   - mehedims2005@gmail.com
-   - hello@mehedims.com
+4. Check **all** recipient email inboxes configured in `CONTACT_RECIPIENTS`.
 5. Also check spam folders!
 
 ### Test 3: Check Logs
@@ -125,7 +108,7 @@ heroku logs --tail
 
 # Look for:
 # "Email sent successfully"
-# "accepted: ['mehedims2005@gmail.com', 'hello@mehedims.com']"
+# "accepted: ['your@email.com', 'another@email.com']"
 ```
 
 ---
@@ -261,8 +244,7 @@ Before going live, verify:
 - [ ] App Password generated
 - [ ] Environment variables set correctly
 - [ ] Test email sent successfully
-- [ ] Email received at mehedims2005@gmail.com
-- [ ] Email received at hello@mehedims.com
+- [ ] Email received at all configured addresses
 - [ ] No errors in logs
 - [ ] Emails not in spam
 
@@ -280,5 +262,5 @@ Before going live, verify:
 
 ---
 
-**You're all set!** Contact form will now send to both `mehedims2005@gmail.com` and `hello@mehedims.com`! 🎉
+**You're all set!** Contact form will now send to your configured recipient addresses! 🎉
 

--- a/app.json
+++ b/app.json
@@ -48,6 +48,10 @@
       "description": "Email address to send from (same as SMTP_USER)",
       "required": true
     },
+    "CONTACT_RECIPIENTS": {
+      "description": "Comma-separated list of email addresses to receive contact form submissions",
+      "required": true
+    },
     "NEXT_PUBLIC_BASE_URL": {
       "description": "Base URL of your deployed application (leave empty for auto-detection)",
       "required": false

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -59,12 +59,15 @@ export async function POST(request: Request) {
       );
     }
 
-    // Send to both email addresses
-    const recipients = ['mehedims2005@gmail.com', 'hello@mehedims.com'];
+    // Use environment variable for recipients or fallback to MAIL_FROM
+    const contactRecipients = process.env.CONTACT_RECIPIENTS;
+    const recipients = contactRecipients
+      ? contactRecipients.split(',').map(email => email.trim())
+      : [process.env.MAIL_FROM || ''];
 
     const mailOptions = {
       from: process.env.MAIL_FROM,
-      to: recipients.join(', '), // Send to both addresses
+      to: recipients.join(', '), // Send to all configured addresses
       subject: `${formName} Contact: ${subject}`,
       replyTo: email,
       text: `

--- a/scripts/check-env.js
+++ b/scripts/check-env.js
@@ -24,7 +24,8 @@ const requiredVars = [
   'SMTP_PORT',
   'SMTP_USER',
   'SMTP_PASSWORD',
-  'MAIL_FROM'
+  'MAIL_FROM',
+  'CONTACT_RECIPIENTS'
 ];
 
 const optionalVars = [


### PR DESCRIPTION
This change addresses a security vulnerability where recipient email addresses were hardcoded in the contact form API route. I have migrated these to a new environment variable `CONTACT_RECIPIENTS` and updated all relevant documentation and configuration files to ensure the system is both secure and maintainable.

---
*PR created automatically by Jules for task [12611867548845207881](https://jules.google.com/task/12611867548845207881) started by @asma019*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the contact-form email delivery configuration and introduces a new required env var; misconfiguration could stop emails or send them to the wrong recipients, but scope is limited to the contact email path and docs/scripts.
> 
> **Overview**
> Updates the contact form email sender to **stop using hardcoded recipient addresses** and instead send to a comma-separated `CONTACT_RECIPIENTS` environment variable (with a fallback to `MAIL_FROM`).
> 
> Adds `CONTACT_RECIPIENTS` to Heroku `app.json` and the `scripts/check-env.js` validator, and refreshes deployment/email documentation (`README.md`, setup/troubleshooting guides) to reflect the new configuration and expected delivery behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4163263160d3dbbdec2eca4bad74193b1ab89cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->